### PR TITLE
Add appinspect, generate-data stages to pipeline

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -33,7 +33,7 @@ jobs:
   generate-data:
     needs: appinspect
     runs-on: ubuntu-latest
-    container: ghcr.io/ermontross/eventgen7_0_0:latest
+    container: ghcr.io/ermontross/eventgen_7_0_0:latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - name: Login into GitHub Container Registry
         uses: docker/login-action@v1
+        with:
           registry: ghrc.io
           username: ${{ github.actor }}
           password: ${{ secrets.CR_PAT }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -15,9 +15,10 @@ jobs:
       - name: Login into GitHub Container Registry
         run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
 
+      - uses: actions/checkout@v2
+
       - name: Run AppInspect
         container: ghcr.io/splunk/appinspect:latest
-        uses: actions/checkout@v2
         run: |
           splunk-appinspect inspect testing_app --output-file appinspect_result.json --mode precert
 
@@ -36,9 +37,10 @@ jobs:
       - name: Login into GitHub Container Registry
         run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
 
+      - uses: actions/checkout@v2
+
       - name: Run Eventgen
         container: ghcr.io/splunk/eventgen7_0_0:latest
-        uses: actions/checkout@v2
         run: |
           mkdir output
           cp -r ./cicd/samples /samples

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,0 +1,45 @@
+name: Test and Build
+
+on: 
+  pull_request:
+    branches:
+      - *
+  push:
+    branches: 
+      - master
+
+jobs:
+  appinspect:
+    runs-on: ghcr.io/splunk/appinspect:latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run AppInspect
+        run: |
+          splunk-appinspect inspect testing_app --output-file appinspect_result.json --mode precert
+
+      - name: Upload AppInspect Results
+        uses: actions/upload-artifact@v2
+        with:
+          name: appinspect
+          path: appinspect_result.json
+
+  generate-data:
+    needs: appinspect
+    runs-on: ghrc.io/splunk/eventgen7_0_0:latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run Eventgen
+        run: |
+          mkdir output
+          cp -r ./cicd/samples /samples
+          splunk_eventgen -v generate ./cicd/eventgen.conf
+
+      - name: Upload Generated Test Data
+        uses: actions/upload-artifact@v2
+        with:
+          name: data
+          path: output/

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -15,8 +15,8 @@ jobs:
       - name: Login into GitHub Container Registry
         run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - container: ghcr.io/splunk/appinspect:latest
       - name: Run AppInspect
+        container: ghcr.io/splunk/appinspect:latest
         uses: actions/checkout@v2
         run: |
           splunk-appinspect inspect testing_app --output-file appinspect_result.json --mode precert
@@ -36,8 +36,8 @@ jobs:
       - name: Login into GitHub Container Registry
         run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - container: ghcr.io/splunk/eventgen7_0_0:latest
       - name: Run Eventgen
+        container: ghcr.io/splunk/eventgen7_0_0:latest
         uses: actions/checkout@v2
         run: |
           mkdir output

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -16,7 +16,7 @@ jobs:
 
   appinspect:
     runs-on: ubuntu-latest
-    container: ghcr.io/splunk/appinspect:latest
+    container: ghcr.io/ermontross/appinspect:latest
 
     steps:
       - uses: actions/checkout@v2
@@ -33,7 +33,7 @@ jobs:
   generate-data:
     needs: appinspect
     runs-on: ubuntu-latest
-    container: ghrc.io/splunk/eventgen7_0_0:latest
+    container: ghrc.io/ermontross/eventgen7_0_0:latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -7,12 +7,10 @@ on:
     branches:
       - master
 
-runs-on: ubuntu-latest
-
 jobs:
   appinspect:
-    container:
-      image: ghcr.io/splunk/appinspect:latest
+    runs-on: ubuntu-latest
+    container: ghcr.io/splunk/appinspect:latest
 
     steps:
       - uses: actions/checkout@v2
@@ -29,8 +27,8 @@ jobs:
 
   generate-data:
     needs: appinspect
-    container:
-      image: ghrc.io/splunk/eventgen7_0_0:latest
+    runs-on: ubuntu-latest
+    container: ghrc.io/splunk/eventgen7_0_0:latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -33,7 +33,7 @@ jobs:
   generate-data:
     needs: appinspect
     runs-on: ubuntu-latest
-    container: ghrc.io/ermontross/eventgen7_0_0:latest
+    container: ghcr.io/ermontross/eventgen7_0_0:latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,11 +1,10 @@
 name: Test and Build
 
-on: 
+on:
   pull_request:
     branches:
-      - *
   push:
-    branches: 
+    branches:
       - master
 
 jobs:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -40,13 +40,9 @@ jobs:
     container: ghrc.io/splunk/eventgen7_0_0:latest
 
     steps:
-      - name: Login into GitHub Container Registry
-        run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
-
       - uses: actions/checkout@v2
 
       - name: Run Eventgen
-        container: ghcr.io/splunk/eventgen7_0_0:latest
         run: |
           mkdir output
           cp -r ./cicd/samples /samples

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -12,11 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Login into GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghrc.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.CR_PAT }}
+        run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
 
   appinspect:
     runs-on: ubuntu-latest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -8,19 +8,24 @@ on:
       - master
 
 jobs:
-  appinspect:
+  login:
     runs-on: ubuntu-latest
-
     steps:
       - name: Login into GitHub Container Registry
-        run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+        uses: docker/login-action@v1
+          registry: ghrc.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.CR_PAT }}
 
+  appinspect:
+    runs-on: ubuntu-latest
+    container: ghcr.io/splunk/appinspect:latest
+
+    steps:
       - uses: actions/checkout@v2
 
       - name: Run AppInspect
-        container: ghcr.io/splunk/appinspect:latest
-        run: |
-          splunk-appinspect inspect testing_app --output-file appinspect_result.json --mode precert
+        run: splunk-appinspect inspect testing_app --output-file appinspect_result.json --mode precert
 
       - name: Upload AppInspect Results
         uses: actions/upload-artifact@v2

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -10,12 +10,14 @@ on:
 jobs:
   appinspect:
     runs-on: ubuntu-latest
-    container: ghcr.io/splunk/appinspect:latest
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Login into GitHub Container Registry
+        run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
 
+      - container: ghcr.io/splunk/appinspect:latest
       - name: Run AppInspect
+        uses: actions/checkout@v2
         run: |
           splunk-appinspect inspect testing_app --output-file appinspect_result.json --mode precert
 
@@ -31,9 +33,12 @@ jobs:
     container: ghrc.io/splunk/eventgen7_0_0:latest
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Login into GitHub Container Registry
+        run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
 
+      - container: ghcr.io/splunk/eventgen7_0_0:latest
       - name: Run Eventgen
+        uses: actions/checkout@v2
         run: |
           mkdir output
           cp -r ./cicd/samples /samples

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -7,9 +7,12 @@ on:
     branches:
       - master
 
+runs-on: ubuntu-latest
+
 jobs:
   appinspect:
-    runs-on: ghcr.io/splunk/appinspect:latest
+    container:
+      image: ghcr.io/splunk/appinspect:latest
 
     steps:
       - uses: actions/checkout@v2
@@ -26,7 +29,8 @@ jobs:
 
   generate-data:
     needs: appinspect
-    runs-on: ghrc.io/splunk/eventgen7_0_0:latest
+    container:
+      image: ghrc.io/splunk/eventgen7_0_0:latest
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Add the `appinspect` and `generate-data` stages to the GitHub Actions pipeline.
* `appinspect` runs AppInspect against the sample-app code and saves the results as a GitHub artifact
* `generate-data` generates test data from the sample files and saves them as GitHub artifacts to be used in later pipeline jobs